### PR TITLE
verify for loader.io

### DIFF
--- a/src/Bcc.Members.Identity.Domain/wwwroot/loaderio-a0931857b8d9f2caf0fcb27f178dd33d.txt
+++ b/src/Bcc.Members.Identity.Domain/wwwroot/loaderio-a0931857b8d9f2caf0fcb27f178dd33d.txt
@@ -1,0 +1,1 @@
+loaderio-a0931857b8d9f2caf0fcb27f178dd33d


### PR DESCRIPTION
To use dummy.login.bcc.no for load testing we need to verify that we control the domain.
Since we use a CName record we can't just do easy dns verification and need to do file based verification instead (hence this PR).